### PR TITLE
Fetch before checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "repository": "soberstadt/mh-qa-cli",
   "scripts": {
+    "start": "./bin/run",
     "posttest": "tslint -p . -t stylish",
     "prepack": "rm -rf lib && tsc -b",
     "test": "echo NO TESTS"

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,8 +169,9 @@ const setApiEnv = async (apiEnvArg: ApiEnv) => {
 
 async function checkoutBranch(branch: string) {
   cli.action.start('🚛  Checking out branch: ' + branch);
+  await exec(`cd ~/code/missionhub-react-native && git fetch origin ${branch}`);
   await exec(
-    'cd ~/code/missionhub-react-native && git checkout -f origin/' + branch,
+    `cd ~/code/missionhub-react-native && git checkout -f origin/${branch}`,
   );
   cli.action.stop();
 }


### PR DESCRIPTION
- Add start command

I had the fetch in the branch selection code before but we replaced it with the `ls-remote`... Oops.